### PR TITLE
Improve integration with HPX on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(LIBCDS_WITH_ASAN "Build ASan+UBSan instrumented code" OFF)
 option(LIBCDS_WITH_TSAN "Build TSan instrumented code" OFF)
 option(LIBCDS_ENABLE_UNIT_TEST "Enable unit test" ON)
 option(LIBCDS_ENABLE_STRESS_TEST "Enable stress test" ON)
-set(CMAKE_TARGET_ARCHITECTURE "" CACHE string "Target build architecture")
+set(CMAKE_TARGET_ARCHITECTURE "" CACHE STRING "Target build architecture")
 
 if(NOT LIBCDS_WITH_HPX)
     find_package(Threads)

--- a/cds/details/defs.h
+++ b/cds/details/defs.h
@@ -349,6 +349,10 @@ namespace cds {}
     }
 #endif
 
+#if CDS_THREADING_HPX
+#include <hpx/config.hpp>
+#endif
+
 // Compiler-specific defines
 #include <cds/compiler/defs.h>
 

--- a/cds/os/thread.h
+++ b/cds/os/thread.h
@@ -15,12 +15,20 @@
 #    include <cds/os/posix/thread.h>
 #endif
 
+#if CDS_THREADING_HPX
+#include <hpx/modules/threading.hpp>
+#endif
+
 namespace cds { namespace OS {
 
     /// Default backoff::yield implementation
     static inline void    backoff()
     {
+#if CDS_THREADING_HPX
         hpx::this_thread::yield();
+#else
+        std::this_thread::yield();
+#endif
     }
 }} // namespace cds::OS
 


### PR DESCRIPTION
- flyby: fixing CMake warning

This small patch enables compiling the branch hpx-thread on Windows