### PR TITLE
More configuration changes for Windows

### DIFF
--- a/cds/os/posix/thread.h
+++ b/cds/os/posix/thread.h
@@ -6,30 +6,42 @@
 #ifndef CDSLIB_OS_POSIX_THREAD_H
 #define CDSLIB_OS_POSIX_THREAD_H
 
-#include <pthread.h>
 #include <signal.h>
 
-#include <hpx/config.hpp>
-#include <hpx/config/defines.hpp>
+#if CDS_THREADING_HPX
 #include <hpx/modules/threading.hpp>
+#else
+#include <pthread.h>
+#endif
 
 namespace cds { namespace OS {
     /// posix-related wrappers
     inline namespace posix {
 
         /// Posix thread id type
+#if CDS_THREADING_HPX
         typedef hpx::threads::thread_id ThreadId;
+#else
+        typedef std::threads::thread_id ThreadId;
+#endif
 
         /// Get current thread id
         static inline ThreadId get_current_thread_id()
         {
-//            return pthread_self();
+#if CDS_THREADING_HPX
             return hpx::threads::get_self_id();
+#else
+            return pthread_self();
+#endif
         }
     }    // namespace posix
 
     //@cond
+#if CDS_THREADING_HPX
     constexpr const posix::ThreadId c_NullThreadId = hpx::threads::invalid_thread_id;
+#else
+    constexpr const posix::ThreadId c_NullThreadId = 0;
+#endif
     //@endcond
 
 }} // namespace cds::OS

--- a/cds/os/win/thread.h
+++ b/cds/os/win/thread.h
@@ -9,24 +9,40 @@
 #ifndef NOMINMAX
 #   define NOMINMAX
 #endif
+#if CDS_THREADING_HPX
+#include <hpx/modules/threading.hpp>
+#else
 #include <windows.h>
+#endif
 
 namespace cds { namespace OS {
     /// Windows-specific functions
     inline namespace Win32 {
 
         /// OS-specific type of thread identifier
+#if CDS_THREADING_HPX
+        typedef hpx::threads::thread_id ThreadId;
+#else
         typedef DWORD           ThreadId;
+#endif
 
         /// Get current thread id
         static inline ThreadId get_current_thread_id()
         {
+#if CDS_THREADING_HPX
+            return hpx::threads::get_self_id();
+#else
             return ::GetCurrentThreadId();
+#endif
         }
     }    // namespace Win32
 
     //@cond
+#if CDS_THREADING_HPX
+    constexpr const Win32::ThreadId c_NullThreadId = hpx::threads::invalid_thread_id;
+#else
     constexpr const Win32::ThreadId c_NullThreadId = 0;
+#endif
     //@endcond
 
 }} // namespace cds::OS

--- a/cds/threading/details/auto_detect.h
+++ b/cds/threading/details/auto_detect.h
@@ -11,14 +11,14 @@
 #   if CDS_COMPILER == CDS_COMPILER_MSVC || (CDS_COMPILER == CDS_COMPILER_INTEL && CDS_OS_INTERFACE == CDS_OSI_WINDOWS)
         // For MSVC, CDS_THREADING_MSVC and CDS_THREADING_WIN_TLS is supported.
         // CDS_THREADING_MSVC must be explicitly defined if needed
-#       if !defined(CDS_THREADING_MSVC) && !defined(CDS_THREADING_WIN_TLS) && !defined(CDS_THREADING_CXX11)
+#       if !defined(CDS_THREADING_MSVC) && !defined(CDS_THREADING_WIN_TLS) && !defined(CDS_THREADING_CXX11) && !defined(CDS_THREADING_HPX)
 #           define CDS_THREADING_WIN_TLS
 #       endif
 #   elif CDS_COMPILER == CDS_COMPILER_GCC || CDS_COMPILER == CDS_COMPILER_CLANG || CDS_COMPILER == CDS_COMPILER_INTEL
         // For GCC, CDS_THREADING_GCC and CDS_THREADING_PTHREAD is supported
         // CDS_THREADING_GCC must be explicitly defined if needed
 #       if CDS_OS_INTERFACE == CDS_OSI_WINDOWS
-#           if !defined(CDS_THREADING_GCC) && !defined(CDS_THREADING_WIN_TLS) && !defined(CDS_THREADING_CXX11)
+#           if !defined(CDS_THREADING_GCC) && !defined(CDS_THREADING_WIN_TLS) && !defined(CDS_THREADING_CXX11) && !defined(CDS_THREADING_HPX)
 #               define CDS_THREADING_WIN_TLS
 #           endif
 #       elif !defined(CDS_THREADING_GCC) && !defined(CDS_THREADING_PTHREAD) && !defined(CDS_THREADING_CXX11) && !defined(CDS_THREADING_HPX)
@@ -33,6 +33,8 @@
 
 #if defined(CDS_THREADING_MSVC)
 #   include <cds/threading/details/msvc.h>
+#elif defined(CDS_THREADING_HPX)
+#   include <cds/threading/details/hpx.h>
 #elif defined(CDS_THREADING_WIN_TLS)
 #   include <cds/threading/details/wintls.h>
 #elif defined(CDS_THREADING_PTHREAD)
@@ -41,8 +43,6 @@
 #   include <cds/threading/details/gcc.h>
 #elif defined(CDS_THREADING_CXX11)
 #   include <cds/threading/details/cxx11.h>
-#elif defined(CDS_THREADING_HPX)
-#   include <cds/threading/details/hpx.h>
 #elif !defined(CDS_THREADING_USER_DEFINED)
 #   error "You must define one of CDS_THREADING_xxx macro before compiling the application"
 #endif

--- a/cds/threading/details/hpx_manager.h
+++ b/cds/threading/details/hpx_manager.h
@@ -74,6 +74,7 @@ namespace cds { namespace threading {
                 {
                     hpx_thread_data = reinterpret_cast<std::size_t>(nullptr);
                     hpx::threads::set_libcds_data(hpx::threads::get_self_id(), hpx_thread_data);
+                    delete pData;
                 }
 
             }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -16,7 +16,7 @@
 #   endif
 #endif
 
-static cds::OS::ThreadId    s_MainThreadId = 0;
+static cds::OS::ThreadId    s_MainThreadId = cds::OS::ThreadId(0);
 static HINSTANCE            s_DllInstance = nullptr;
 
 #if _WIN32_WINNT < 0x0601

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -11,7 +11,11 @@
 #   if CDS_COMPILER == CDS_COMPILER_MSVC || CDS_COMPILER == CDS_COMPILER_INTEL
 #       include <cds/threading/details/msvc_manager.h>
 #   endif
+#   ifdef CDS_THREADING_HPX
+#        include <cds/threading/details/hpx_manager.h>
+#   else
 #   include <cds/threading/details/wintls_manager.h>
+#   endif
 #else   // CDS_OS_INTERFACE != CDS_OSI_WINDOWS
 #   if CDS_COMPILER == CDS_COMPILER_GCC || CDS_COMPILER == CDS_COMPILER_CLANG || CDS_COMPILER == CDS_COMPILER_INTEL
 #       include <cds/threading/details/gcc_manager.h>
@@ -29,7 +33,7 @@
 
 namespace cds {
 
-#if CDS_OS_INTERFACE == CDS_OSI_WINDOWS
+#if CDS_OS_INTERFACE == CDS_OSI_WINDOWS && !defined(CDS_THREADING_HPX)
     CDS_EXPORT_API DWORD cds::threading::wintls::Manager::Holder::m_key = TLS_OUT_OF_INDEXES;
 #   if CDS_COMPILER == CDS_COMPILER_MSVC || CDS_COMPILER == CDS_COMPILER_INTEL
         __declspec( thread ) threading::msvc_internal::ThreadDataPlaceholder threading::msvc_internal::s_threadData;
@@ -37,10 +41,7 @@ namespace cds {
 #   endif
 #else
 
-#   ifdef CDS_THREADING_HPX
-//    threading::hpx_internal::ThreadDataPlaceholder threading::hpx_internal::s_threadData;
-//    threading::ThreadData * threading::hpx_internal::s_pThreadData = nullptr;
-#   else
+#   ifndef CDS_THREADING_HPX
     pthread_key_t threading::pthread::Manager::Holder::m_key;
 #   endif
 


### PR DESCRIPTION
- flyby: delete allocated thread data

@weilewei as it turns out, #2 was not entirely done yet... Here is more.